### PR TITLE
DELETE /widgets/{id} returnes 405"

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -49,6 +49,7 @@ class WidgetsController < ApplicationController
     widget = Widget.find(params[:id])
 
     widget.destroy!
+    head :no_content
   rescue ActiveRecord::RecordNotFound
     render problem: { detail: 'The requested widget does not exist.' }, status: :not_found
   end

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -2,19 +2,19 @@ class WidgetsController < ApplicationController
 
   # GET /widgets
   def index
-    @widgets = Widget.all
+    widgets = Widget.all
 
-    if stale? @widgets
-      render json: @widgets
+    if stale? widgets
+      render json: widgets
     end
   end
 
   # GET /widgets/:id
   def show
-    @widget = Widget.find(params[:id])
+    widget = Widget.find(params[:id])
 
-    if stale? @widget
-      render json: @widget
+    if stale? widget
+      render json: widget
     end
   rescue ActiveRecord::RecordNotFound
     render problem: { detail: 'The requested widget does not exist.' }, status: :not_found
@@ -22,23 +22,23 @@ class WidgetsController < ApplicationController
 
   # POST /widgets
   def create
-    @widget = Widget.new(widget_params)
+    widget = Widget.new(widget_params)
 
-    if @widget.save
-      render location: @widget, status: :created
+    if widget.save
+      render location: widget, status: :created
     else
-      render problem: { errors: @widget.errors }, status: :bad_request
+      render problem: { errors: widget.errors }, status: :bad_request
     end
   end
 
   # PUT /widgets/:id
   def update
-    @widget = Widget.find(params[:id])
+    widget = Widget.find(params[:id])
 
-    if @widget.update(widget_params)
-      render json: @widget
+    if widget.update(widget_params)
+      render json: widget
     else
-      render problem: { errors: @widget.errors }, status: :bad_request
+      render problem: { errors: widget.errors }, status: :bad_request
     end
   rescue ActiveRecord::RecordNotFound
     render problem: { detail: 'The requested widget does not exist.' }, status: :not_found
@@ -46,9 +46,9 @@ class WidgetsController < ApplicationController
 
   # DELETE /widgets/:id
   def destroy
-    @widget = Widget.find(params[:id])
+    widget = Widget.find(params[:id])
 
-    @widget.destroy!
+    widget.destroy!
   rescue ActiveRecord::RecordNotFound
     render problem: { detail: 'The requested widget does not exist.' }, status: :not_found
   end

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -73,4 +73,23 @@ RSpec.describe 'Widgets Requests', type: :request do
       expect(response).to match_openapi_doc(OPENAPI_DOC)
     end
   end
+
+  describe "DELETE /widgets/{id}" do
+    it 'responds with 204 for existing record' do
+      widget = create(:widget)
+
+      delete '/widgets/' + widget.id
+      expect(response).to have_http_status(:no_content)
+      expect(response).to match_openapi_doc(OPENAPI_DOC)
+
+      # Ensure the widget was deleted
+      expect(Widget.exists?(widget.id)).to be_falsey
+    end
+
+    it 'responds with 404 for non-existing record' do
+      delete '/widgets/' + SecureRandom.uuid_v7
+      expect(response).to have_http_status(:not_found)
+      expect(response).to match_openapi_doc(OPENAPI_DOC)
+    end
+  end
 end

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Widgets Requests', type: :request do
     it 'responds with 204 for existing record' do
       widget = create(:widget)
 
-      delete '/widgets/' + widget.id
+      delete "/widgets/#{widget.id}"
       expect(response).to have_http_status(:no_content)
       expect(response).to match_openapi_doc(OPENAPI_DOC)
 


### PR DESCRIPTION
Despite showing up in `rails routes`, for some reason `DELETE /widgets/id` responds with a 405 Method Not Allowed.

Prodding it with curl does not show any logger activity so somewhere its getting lost.